### PR TITLE
feat: Update SVG rendering for rewind and fast forward icons with new dimensions and styles

### DIFF
--- a/src/content/__tests__/helper.spec.ts
+++ b/src/content/__tests__/helper.spec.ts
@@ -90,9 +90,9 @@ describe('getSeconds', () => {
 
 describe('createFastRewindSVG', () => {
   const rewindSvg = `
-      <svg class="" height="100%" width="100%" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path class="" id="custom-path-rewind" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z" />
-      </svg>`;
+       <svg class="" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+          <path id="custom-path-rewind" class="" d="M856-240 505.33-480 856-720v480Zm-401.33 0L104-480l350.67-240v480Z" />
+    </svg>`;
   const xLinkAttrCustomId = '#custom-path-rewind';
 
   it('should return the correct svg', () => {
@@ -165,9 +165,9 @@ describe('createFastRewindSVG', () => {
 
 describe('createFastForwardSVG', () => {
   const forwardSvg = `
-      <svg class="" height="100%" width="100%" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path class="" id="custom-path-fast-forward" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z" />
-      </svg>`;
+      <svg class="" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+      <path id="custom-path-fast-forward" class="" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" />
+    </svg>`;
   const xLinkAttrCustomId = '#custom-path-fast-forward';
 
   it('should return the correct svg', () => {

--- a/src/content/helper.ts
+++ b/src/content/helper.ts
@@ -34,12 +34,12 @@ export function createFastRewindSVG(
   svgPathClasses: string[]
 ): string {
   return `
-    <svg class="${svgClasses}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+    <svg class="${svgClasses.join(' ')}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
        ${svgUseHtml.replace(
          /xlink:href="#.*"/,
          'xlink:href="#custom-path-rewind"'
        )}
-      <path id="custom-path-rewind" class="${svgPathClasses}" d="M856-240 505.33-480 856-720v480Zm-401.33 0L104-480l350.67-240v480Z" />
+      <path id="custom-path-rewind" class="${svgPathClasses.join(' ')}" d="M856-240 505.33-480 856-720v480Zm-401.33 0L104-480l350.67-240v480Z" />
     </svg>
   `;
 }
@@ -50,12 +50,12 @@ export function createFastForwardSVG(
   svgPathClasses: string[]
 ): string {
   return `
-    <svg class="${svgClasses}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+    <svg class="${svgClasses.join(' ')}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
       ${svgUseHtml.replace(
         /xlink:href="#.*"/,
         'xlink:href="#custom-path-fast-forward"'
       )}
-      <path id="custom-path-fast-forward" class="${svgPathClasses}" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" />
+      <path id="custom-path-fast-forward" class="${svgPathClasses.join(' ')}" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" />
     </svg>
   `;
 }

--- a/src/content/helper.ts
+++ b/src/content/helper.ts
@@ -55,7 +55,7 @@ export function createFastForwardSVG(
         /xlink:href="#.*"/,
         'xlink:href="#custom-path-fast-forward"'
       )}
-      <path id="custom-path-fast-forward class="${svgPathClasses}" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" "/>
+      <path id="custom-path-fast-forward" class="${svgPathClasses}" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" />
     </svg>
   `;
 }

--- a/src/content/helper.ts
+++ b/src/content/helper.ts
@@ -34,12 +34,12 @@ export function createFastRewindSVG(
   svgPathClasses: string[]
 ): string {
   return `
-    <svg class="${svgClasses}" height="100%" width="100%" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      ${svgUseHtml.replace(
-        /xlink:href="#.*"/,
-        'xlink:href="#custom-path-rewind"'
-      )}
-      <path class="${svgPathClasses}" id="custom-path-rewind" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0019 16V8a1 1 0 00-1.6-.8l-5.333 4zM4.066 11.2a1 1 0 000 1.6l5.334 4A1 1 0 0011 16V8a1 1 0 00-1.6-.8l-5.334 4z" />
+    <svg class="${svgClasses}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+       ${svgUseHtml.replace(
+         /xlink:href="#.*"/,
+         'xlink:href="#custom-path-rewind"'
+       )}
+      <path id="custom-path-rewind" class="${svgPathClasses}" d="M856-240 505.33-480 856-720v480Zm-401.33 0L104-480l350.67-240v480Z" />
     </svg>
   `;
 }
@@ -50,12 +50,12 @@ export function createFastForwardSVG(
   svgPathClasses: string[]
 ): string {
   return `
-    <svg class="${svgClasses}" height="100%" width="100%" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    ${svgUseHtml.replace(
-      /xlink:href="#.*"/,
-      'xlink:href="#custom-path-fast-forward"'
-    )}
-      <path class="${svgPathClasses}" id="custom-path-fast-forward" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.933 12.8a1 1 0 000-1.6L6.6 7.2A1 1 0 005 8v8a1 1 0 001.6.8l5.333-4zM19.933 12.8a1 1 0 000-1.6l-5.333-4A1 1 0 0013 8v8a1 1 0 001.6.8l5.333-4z" />
+    <svg class="${svgClasses}" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 -960 960 960" width="100%" fill="#e3e3e3">
+      ${svgUseHtml.replace(
+        /xlink:href="#.*"/,
+        'xlink:href="#custom-path-fast-forward"'
+      )}
+      <path id="custom-path-fast-forward class="${svgPathClasses}" d="M102.67-240v-480l350.66 240-350.66 240Zm404.66 0v-480L858-480 507.33-240Z" "/>
     </svg>
   `;
 }


### PR DESCRIPTION
This pull request includes updates to the SVG rendering functions in `src/content/helper.ts`. The main changes involve modifying the SVG elements' to use Google Fonts to align the style with the other buttons for the `createFastRewindSVG` and `createFastForwardSVG` functions.

Updates to SVG rendering functions:

* [`createFastRewindSVG`](diffhunk://#diff-67d0742bfa775705dada59ce5d7a6a11a945a1b8d15a016f8f55cbcd36070af7L37-R42): Changed to [google font](https://fonts.google.com/icons?icon.query=rewind&icon.size=36&icon.color=%23e3e3e3&selected=Material+Symbols+Outlined:fast_rewind:FILL@1;wght@400;GRAD@0;opsz@40).
* [`createFastForwardSVG`](diffhunk://#diff-67d0742bfa775705dada59ce5d7a6a11a945a1b8d15a016f8f55cbcd36070af7L53-R58): Changed to [google font](https://fonts.google.com/icons?icon.query=play&icon.size=36&icon.color=%23e3e3e3&selected=Material+Symbols+Outlined:fast_forward:FILL@1;wght@400;GRAD@0;opsz@40).

- Resolves #63 .

---

#### Before:
![image](https://github.com/user-attachments/assets/09680aad-8067-48f1-97ce-24095366f156)

#### After: 
![image](https://github.com/user-attachments/assets/b20cf861-de7e-42a6-9f52-6cff2a5c10f0)
