### PR TITLE
Fix wording for deprecated option comments

### DIFF
--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -10,7 +10,7 @@ export interface IOptions {
     rewindSeconds: number;
     forwardSeconds: number;
   };
-  shouldOverrideKeys?: boolean; // TODO: old one, should removed in the next version
+  shouldOverrideKeys?: boolean; // TODO: old one, should be removed in the next version
   shouldOverrideArrowKeys: boolean;
   shouldOverrideMediaKeys: boolean;
 }

--- a/src/options/options-page.ts
+++ b/src/options/options-page.ts
@@ -9,7 +9,7 @@ const OPTIONS_DEFAULT_VALUES: Readonly<IOptions> = {
     rewindSeconds: 5,
     forwardSeconds: 5,
   },
-  shouldOverrideKeys: false, // TODO: old one, should removed in the next version
+  shouldOverrideKeys: false, // TODO: old one, should be removed in the next version
   shouldOverrideArrowKeys: false,
   shouldOverrideMediaKeys: false,
 };


### PR DESCRIPTION
## Summary
- update TODO text describing old `shouldOverrideKeys` option

## Testing
- `npm run check`
- `npm run eslint` *(fails: @typescript-eslint/no-require-imports errors)*