### PR TITLE
Bump version to 1.4.4 in package.json, package-lock.json, and manifest.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "youtube-rewind-fastforward-buttons",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "youtube-rewind-fastforward-buttons",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "ISC",
       "dependencies": {
         "@picocss/pico": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-rewind-fastforward-buttons",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Add Fast Rewind & Forward buttons to videos player in YouTube site, same as the Left / Right arrow keys.",
   "targets": {
     "webext-dev": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
   "short_name": "YouTube Rewind&Forward Buttons",
   "name": "YouTube Rewind & Fast Forward Buttons",
   "description": "Add Rewind & Fast Forward buttons to videos player in a YouTube site",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "content_scripts": [
     {
       "matches": ["https://www.youtube.com/*"],


### PR DESCRIPTION
This pull request includes a minor version bump for the YouTube Rewind & Fast Forward Buttons extension. The update changes the version number from 1.4.3 to 1.4.4 in both the `package.json` and `manifest.json` files. No functional changes are included.