### PR TITLE
Content foldert restructure: Logical Subfolders and Shared Types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ Keep guidance concise and actionable. If you change behavior that affects tests,
 
 Key locations and why they matter
 - `src/` — extension implementation. Important subfolders:
-  - `content/` — injected scripts that interact with the YouTube player (e.g. `content.ts`, `buttons.ts`, `handle-video-player.ts`, `event-keys.ts`, `tooltip.ts`, `helper.ts`, `types.ts`). Changes here affect runtime behavior and E2E tests.
+  - `shared/` — shared types (`types.ts`). Used by content and options.
+  - `content/` — injected scripts that interact with the YouTube player. Entry: `content.ts`. Subfolders: `buttons/` (buttons, helper), `player/` (handle-video-player, wait-for-player), `events/` (event-keys), `ui/` (tooltip, button-styles-sync). `selectors.ts` remains at root. Changes here affect runtime behavior and E2E tests.
     - `selectors.ts` — Centralized location for all YouTube DOM selectors. Use this to maintain consistency and avoid magic strings.
   - `background/` — service worker logic and feature flags (see `service-worker.ts`). Use this for cross-tab state and messaging.
     - `whats-new-page/` — changelog page shown automatically on extension updates. Includes HTML, CSS, TypeScript, tests, and test helpers.
@@ -38,7 +39,7 @@ Important developer workflows (commands)
   - `npm run updateVersion` — update version script utility.
 
 Project-specific patterns and conventions
-- TypeScript-first: prefer explicit interfaces and enums. Shared types are in `types.d.ts`, content-specific types are in `src/content/types.ts`.
+- TypeScript-first: prefer explicit interfaces and enums. Shared types are in `types.d.ts` and `src/shared/types.ts`.
 - Place shared interfaces first, then types, followed by module-level `const` declarations directly after imports and before any function bodies.
 - File naming: kebab-case for files (e.g. `buttons.ts`), PascalCase for classes/components, camelCase for variables.
 - Tests: colocate test helpers under `__utils__` and name specs `<feature>.spec.ts` or `<feature>.test.ts`.
@@ -58,7 +59,7 @@ Project-specific patterns and conventions
 
 Integration and messaging
 - Content scripts communicate with the background service worker via standard chrome.runtime messaging. Look for usages of `chrome.runtime.sendMessage` and `chrome.runtime.onMessage` across `content/` and `background/`.
-- Options page persists settings that content scripts read; the `options-page.ts` and `content/helper.ts` are good starting points to trace the settings flow.
+- Options page persists settings that content scripts read; the `options-page.ts` and `content/buttons/helper.ts` are good starting points to trace the settings flow.
 
 Examples of repository-specific intents
 - When changing a selector used by the Playwright tests, update the tests under `e2e-tests/` and update any screenshots in `screenshots/`.
@@ -70,7 +71,7 @@ Small rules for AI edits
 - Preserve public APIs (message formats, settings keys in `types.d.ts`) unless you update all callsites and tests.
 
 Where to look when debugging
-- Runtime issues on YouTube pages: `src/content/*` and `src/content/handle-video-player.ts`.
+- Runtime issues on YouTube pages: `src/content/*` and `src/content/player/handle-video-player.ts`.
 - Background messaging/state: `src/background/service-worker.ts`.
 - Options/serialization bugs: `src/options/options-page.ts`.
 - Packaging / build quirks: `scripts/fix-pico-paths.mjs` and `package.json` scripts.

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -1,0 +1,31 @@
+# Content Folder
+
+This folder contains the injected YouTube content-script runtime.
+It adds rewind/forward buttons to the player and handles keyboard shortcuts.
+
+## Entry Point
+
+- `content.ts` is the manifest entry and orchestrates initialization, SPA navigation handling, options loading, and keyboard wiring.
+
+## Structure
+
+| Path | Role |
+| --- | --- |
+| `content.ts` | Entry point: init, SPA navigation, options loading, keyboard handlers |
+| `selectors.ts` | Centralized YouTube DOM selectors |
+| `content-styles.css` | Styles for the custom buttons |
+| `content-trigger-flows.md` | Trigger-flow and lifecycle documentation |
+| `buttons/` | Button UI: creation, SVG generation, labels/titles |
+| `player/` | Video/player logic: seek updates and player-ready polling |
+| `events/` | Keyboard handling: arrow/media key behavior |
+| `ui/` | UI helpers: tooltip behavior and native-style syncing |
+| `__tests__/` | Unit tests for content modules |
+| `__utils__/` | Test fixtures/helpers for content tests |
+
+## Shared Types
+
+- Shared interfaces and enums used by content and options live in `src/shared/types.ts`.
+
+## Related Docs
+
+- See `content-trigger-flows.md` for startup, SPA navigation, fallback observer, and cleanup flows.

--- a/src/content/__tests__/button-styles-sync.spec.ts
+++ b/src/content/__tests__/button-styles-sync.spec.ts
@@ -1,12 +1,12 @@
+import { ButtonClassesIds } from '../../shared/types';
 import { createNewUiPlayerMarkup } from '../__utils__/tests-helper';
+import { YouTubeSelectors } from '../selectors';
 import {
   isNewUiPlayer,
   resetIsNewUiPlayerCache,
   setupCustomButtonsStylesSync,
   teardownNativeButtonSyncIfUnused,
-} from '../button-styles-sync';
-import { ButtonClassesIds } from '../types';
-import { YouTubeSelectors } from '../selectors';
+} from '../ui/button-styles-sync';
 
 const mockResizeObserver = {
   observe: jest.fn(),

--- a/src/content/__tests__/buttons.spec.ts
+++ b/src/content/__tests__/buttons.spec.ts
@@ -1,4 +1,5 @@
 import { chrome } from 'jest-chrome';
+import { ArrowKey, ButtonClassesIds } from '../../shared/types';
 import {
   DEFAULT_OPTIONS_MOCK,
   HTML_PLAYER_FULL,
@@ -13,11 +14,10 @@ import buttons, {
   addButtonsToVideo,
   handleArrowButtons,
   updateButtons,
-} from '../buttons';
+} from '../buttons/buttons';
 import { loadOptions } from '../content';
-import * as eventKeys from '../event-keys';
-import * as handleVideoPlayer from '../handle-video-player';
-import { ArrowKey, ButtonClassesIds } from '../types';
+import * as eventKeys from '../events/event-keys';
+import * as handleVideoPlayer from '../player/handle-video-player';
 import { YouTubeSelectors } from '../selectors';
 
 describe('handleArrowButtons', () => {

--- a/src/content/__tests__/content.spec.ts
+++ b/src/content/__tests__/content.spec.ts
@@ -1,18 +1,5 @@
 /* eslint-disable sonarjs/no-nested-functions */
 import { chrome } from 'jest-chrome';
-import * as buttons from '../buttons';
-import * as eventKeys from '../event-keys';
-import content, {
-  run,
-  loadOptions,
-  mergeOptions,
-  handleOverrideKeysMigration,
-} from '../content';
-import {
-  DEFAULT_OPTIONS_MOCK,
-  HTML_PLAYER_FULL,
-  INITIAL_HTML_PLAYER_FULL,
-} from '../__utils__/tests-helper';
 import {
   ArrowKey,
   ButtonClassesIds,
@@ -21,9 +8,22 @@ import {
   IStorageOptions,
   KEY_CODES,
   MediaTrackKey,
-} from '../types';
+} from '../../shared/types';
+import {
+  DEFAULT_OPTIONS_MOCK,
+  HTML_PLAYER_FULL,
+  INITIAL_HTML_PLAYER_FULL,
+} from '../__utils__/tests-helper';
+import * as buttons from '../buttons/buttons';
+import content, {
+  handleOverrideKeysMigration,
+  loadOptions,
+  mergeOptions,
+  run,
+} from '../content';
+import * as eventKeys from '../events/event-keys';
+import * as waitForPlayer from '../player/wait-for-player';
 import { YouTubeSelectors } from '../selectors';
-import * as waitForPlayer from '../wait-for-player';
 
 describe('full run', () => {
   const originalConsoleError = console.error;

--- a/src/content/__tests__/event-keys.spec.ts
+++ b/src/content/__tests__/event-keys.spec.ts
@@ -1,16 +1,16 @@
+import { ArrowKey, KEY_CODES, MediaTrackKey } from '../../shared/types';
+import {
+  DEFAULT_OPTIONS_MOCK,
+  HTML_PLAYER_FULL,
+} from '../__utils__/tests-helper';
 import {
   isShouldSkipOverrideArrowKeys,
   overrideArrowKeys,
   overrideMediaKeys,
   shouldSkipDueToFocus,
   simulateKey,
-} from '../event-keys';
-import { ArrowKey, KEY_CODES, MediaTrackKey } from '../types';
-import {
-  DEFAULT_OPTIONS_MOCK,
-  HTML_PLAYER_FULL,
-} from '../__utils__/tests-helper';
-import * as handleVideoPlayer from '../handle-video-player';
+} from '../events/event-keys';
+import * as handleVideoPlayer from '../player/handle-video-player';
 
 describe('simulateKey', () => {
   const leftKeyEvent = new KeyboardEvent('keydown', {

--- a/src/content/__tests__/handle-video-player.spec.ts
+++ b/src/content/__tests__/handle-video-player.spec.ts
@@ -1,5 +1,5 @@
-import { updateVideoTime } from '../handle-video-player';
-import { ArrowKey } from '../types';
+import { ArrowKey } from '../../shared/types';
+import { updateVideoTime } from '../player/handle-video-player';
 
 describe('updateVideoTime', () => {
   const videoElement = document.createElement('video');

--- a/src/content/__tests__/helper.spec.ts
+++ b/src/content/__tests__/helper.spec.ts
@@ -1,3 +1,4 @@
+import { ArrowKey, ButtonClassesIds } from '../../shared/types';
 import {
   createSvgMock,
   DEFAULT_OPTIONS_MOCK,
@@ -7,7 +8,6 @@ import {
   SVG_PATH_CLASSES_MOCK,
   X_LINK_ATTR,
 } from '../__utils__/tests-helper';
-import { resetIsNewUiPlayerCache } from '../button-styles-sync';
 import {
   createButton,
   createFastDoubleForwardSVG,
@@ -26,8 +26,8 @@ import {
   oldUiCreateFastDoubleRewindSVG,
   oldUiCreateFastForwardSVG,
   oldUiCreateFastRewindSVG,
-} from '../helper';
-import { ArrowKey, ButtonClassesIds } from '../types';
+} from '../buttons/helper';
+import { resetIsNewUiPlayerCache } from '../ui/button-styles-sync';
 
 const MODERN_PLAYER_MARKUP = '<div class="ytp-delhi-modern"></div>';
 

--- a/src/content/__tests__/tooltip.spec.ts
+++ b/src/content/__tests__/tooltip.spec.ts
@@ -1,19 +1,19 @@
-jest.mock('../button-styles-sync', () => {
-  const actual = jest.requireActual('../button-styles-sync');
+jest.mock('../ui/button-styles-sync', () => {
+  const actual = jest.requireActual('../ui/button-styles-sync');
   return {
     ...actual,
     isNewUiPlayer: jest.fn(() => false),
   };
 });
 
-import { isNewUiPlayer } from '../button-styles-sync';
+import { HTML_PLAYER_FULL } from '../__utils__/tests-helper';
+import { YouTubeSelectors } from '../selectors';
+import { isNewUiPlayer } from '../ui/button-styles-sync';
 import {
   getElementsForTooltipCalculation,
   handleTooltipOnMouseLeave,
   handleTooltipOnMouseOver,
-} from '../tooltip';
-import { HTML_PLAYER_FULL } from '../__utils__/tests-helper';
-import { YouTubeSelectors } from '../selectors';
+} from '../ui/tooltip';
 
 const mockIsNewUiPlayer = isNewUiPlayer as jest.MockedFunction<
   typeof isNewUiPlayer

--- a/src/content/__tests__/wait-for-player.spec.ts
+++ b/src/content/__tests__/wait-for-player.spec.ts
@@ -1,17 +1,17 @@
 import {
-  waitForPlayerElements,
+  HTML_MINIMAL_NO_PLAYER,
+  HTML_PLAYER_CONTROLS_NO_ANCHOR,
+  HTML_PLAYER_PLAY_BUTTON_ONLY,
+  HTML_PLAYER_READY,
+  HTML_PLAYER_VIDEO_ONLY,
+  INITIAL_HTML_PLAYER_FULL,
+} from '../__utils__/tests-helper';
+import {
   abortWait,
   bindWaitCleanup,
   resetWaitState,
-} from '../wait-for-player';
-import {
-  HTML_PLAYER_READY,
-  HTML_PLAYER_VIDEO_ONLY,
-  HTML_PLAYER_PLAY_BUTTON_ONLY,
-  HTML_PLAYER_CONTROLS_NO_ANCHOR,
-  HTML_MINIMAL_NO_PLAYER,
-  INITIAL_HTML_PLAYER_FULL,
-} from '../__utils__/tests-helper';
+  waitForPlayerElements,
+} from '../player/wait-for-player';
 
 describe('waitForPlayerElements', () => {
   let rafCallbacks: FrameRequestCallback[] = [];

--- a/src/content/__utils__/tests-helper.ts
+++ b/src/content/__utils__/tests-helper.ts
@@ -1,5 +1,5 @@
-import { createFastRewindSVG, createFastForwardSVG } from '../helper';
-import { IOptions } from '../types';
+import { IOptions } from '../../shared/types';
+import { createFastForwardSVG, createFastRewindSVG } from '../buttons/helper';
 
 export const HTML_PLAYER_FULL = /* html */ `
 <ytd-player>

--- a/src/content/buttons/buttons.ts
+++ b/src/content/buttons/buttons.ts
@@ -1,5 +1,18 @@
-import { simulateKey } from './event-keys';
-import { updateVideoTime } from './handle-video-player';
+import {
+  ArrowKey,
+  ButtonClassesIds,
+  ButtonExtraStylesArg,
+  IOptions,
+  VideoTimeArg,
+} from '../../shared/types';
+import { simulateKey } from '../events/event-keys';
+import { updateVideoTime } from '../player/handle-video-player';
+import { YouTubeSelectors } from '../selectors';
+import { teardownNativeButtonSyncIfUnused } from '../ui/button-styles-sync';
+import {
+  handleTooltipOnMouseLeave,
+  handleTooltipOnMouseOver,
+} from '../ui/tooltip';
 import {
   createButton,
   createFastDoubleForwardSVG,
@@ -10,16 +23,6 @@ import {
   createRewindButtonTitle,
   createTitle,
 } from './helper';
-import { teardownNativeButtonSyncIfUnused } from './button-styles-sync';
-import { handleTooltipOnMouseLeave, handleTooltipOnMouseOver } from './tooltip';
-import {
-  ArrowKey,
-  ButtonClassesIds,
-  ButtonExtraStylesArg,
-  IOptions,
-  VideoTimeArg,
-} from './types';
-import { YouTubeSelectors } from './selectors';
 
 export function handleArrowButtons({
   seconds,

--- a/src/content/buttons/helper.ts
+++ b/src/content/buttons/helper.ts
@@ -1,8 +1,13 @@
-import { ArrowKey, ButtonClassesIds, CreateButtonArg, IOptions } from './types';
+import {
+  ArrowKey,
+  ButtonClassesIds,
+  CreateButtonArg,
+  IOptions,
+} from '../../shared/types';
 import {
   isNewUiPlayer,
   setupCustomButtonsStylesSync,
-} from './button-styles-sync';
+} from '../ui/button-styles-sync';
 
 // Keep custom icons visually aligned with YouTube's native play button.
 // The shapes are normalized to a 24x24 viewBox, then uniformly scaled down a touch.

--- a/src/content/content-trigger-flows.md
+++ b/src/content/content-trigger-flows.md
@@ -2,6 +2,8 @@
 
 This document maps the trigger paths in the content script: startup init, SPA navigation, fallback recovery, `src` observer behavior, and reset/cleanup.
 
+Related modules: `content.ts` (this document), `content/player/wait-for-player.ts` (`waitForPlayerElements`, `bindWaitCleanup`, `abortWait`).
+
 ## 1) Module load startup flow
 
 ```mermaid

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,21 +1,21 @@
-import { addButtonsToVideo, updateButtons } from './buttons';
-import {
-  overrideArrowKeys,
-  overrideMediaKeys,
-  shouldSkipDueToFocus,
-} from './event-keys';
 import {
   ButtonClassesIds,
   ChromeStorageChanges,
   IOptions,
   IStorageOptions,
-} from './types';
-import { YouTubeSelectors } from './selectors';
+} from '../shared/types';
+import { addButtonsToVideo, updateButtons } from './buttons/buttons';
 import {
-  waitForPlayerElements,
-  bindWaitCleanup,
+  overrideArrowKeys,
+  overrideMediaKeys,
+  shouldSkipDueToFocus,
+} from './events/event-keys';
+import {
   abortWait,
-} from './wait-for-player';
+  bindWaitCleanup,
+  waitForPlayerElements,
+} from './player/wait-for-player';
+import { YouTubeSelectors } from './selectors';
 
 // #region SPA Navigation State
 

--- a/src/content/events/event-keys.ts
+++ b/src/content/events/event-keys.ts
@@ -1,12 +1,12 @@
-import { getSeconds as eventKeys } from './helper';
-import { updateVideoTime } from './handle-video-player';
 import {
   ALL_ARROW_KEY_CODES,
   ArrowKey,
   IOptions,
   KEY_CODES,
   MediaTrackKey,
-} from './types';
+} from '../../shared/types';
+import { getSeconds as eventKeys } from '../buttons/helper';
+import { updateVideoTime } from '../player/handle-video-player';
 
 const MEDIA_KEYS_TO_ARROW_KEYS = {
   [MediaTrackKey.MEDIA_TRACK_PREVIOUS]: ArrowKey.ARROW_LEFT_KEY,

--- a/src/content/player/handle-video-player.ts
+++ b/src/content/player/handle-video-player.ts
@@ -1,4 +1,4 @@
-import { ArrowKey, VideoTimeArg } from './types';
+import { ArrowKey, VideoTimeArg } from '../../shared/types';
 
 export function updateVideoTime({
   seconds,

--- a/src/content/player/wait-for-player.ts
+++ b/src/content/player/wait-for-player.ts
@@ -1,4 +1,4 @@
-import { YouTubeSelectors } from './selectors';
+import { YouTubeSelectors } from '../selectors';
 
 // #region Types
 

--- a/src/content/ui/button-styles-sync.ts
+++ b/src/content/ui/button-styles-sync.ts
@@ -1,5 +1,5 @@
-import { ButtonClassesIds } from './types';
-import { YouTubeSelectors } from './selectors';
+import { ButtonClassesIds } from '../../shared/types';
+import { YouTubeSelectors } from '../selectors';
 
 type StylableElement = HTMLButtonElement | SVGElement;
 

--- a/src/content/ui/tooltip.ts
+++ b/src/content/ui/tooltip.ts
@@ -1,5 +1,5 @@
+import { YouTubeSelectors } from '../selectors';
 import { isNewUiPlayer } from './button-styles-sync';
-import { YouTubeSelectors } from './selectors';
 
 export function getElementsForTooltipCalculation(): {
   tooltipContainer: HTMLElement;

--- a/src/options/__tests__/options-page.spec.ts
+++ b/src/options/__tests__/options-page.spec.ts
@@ -1,6 +1,6 @@
 import { chrome } from 'jest-chrome';
 import { describe } from 'node:test';
-import { IStorageOptions } from '../../content/types';
+import { IStorageOptions } from '../../shared/types';
 import {
   DEFAULT_OPTIONS_MOCK,
   DEFAULT_STORAGE_OPTIONS_MOCK,
@@ -220,7 +220,7 @@ describe('Options page', () => {
     it('should if user approve confirm, should run sync.set', async () => {
       (window.confirm as jest.Mock).mockReturnValue(true);
       await resetToDefaultOptions();
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
       const defaultOpinions = { ...DEFAULT_OPTIONS_MOCK };
       defaultOpinions.shouldOverrideKeys = false;
       expect(chrome.storage.sync.set).toHaveBeenCalledWith(defaultOpinions);

--- a/src/options/__utils__/tests-helper.ts
+++ b/src/options/__utils__/tests-helper.ts
@@ -1,4 +1,4 @@
-import { IOptions, IStorageOptions } from '../../content/types';
+import { IOptions, IStorageOptions } from '../../shared/types';
 
 export const MOCK_HTML = /* HTML */ `
   <header class="container-fluid">

--- a/src/options/options-page.ts
+++ b/src/options/options-page.ts
@@ -1,5 +1,5 @@
-import { numberFormat } from '../content/helper';
-import { IOptions, IStorageOptions, Prettify } from '../content/types';
+import { numberFormat } from '../content/buttons/helper';
+import { IOptions, IStorageOptions, Prettify } from '../shared/types';
 
 const OPTIONS_DEFAULT_VALUES: Readonly<IOptions> = {
   rewindSeconds: 5,
@@ -152,7 +152,6 @@ export async function loadInputStorageOptions(): Promise<void> {
 }
 
 export async function resetToDefaultOptions(): Promise<void> {
-  /* eslint-disable-next-line no-alert, no-restricted-globals */
   const result = window.confirm('Are you sure?');
   if (!result) {
     return;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,11 +15,10 @@ export interface IOptions {
   shouldOverrideMediaKeys: boolean;
 }
 
-export interface IStorageOptions
-  extends Omit<
-    IOptions,
-    'rewindSeconds' | 'forwardSeconds' | 'secondarySeconds'
-  > {
+export interface IStorageOptions extends Omit<
+  IOptions,
+  'rewindSeconds' | 'forwardSeconds' | 'secondarySeconds'
+> {
   rewindSeconds: string;
   forwardSeconds: string;
   secondarySeconds: {


### PR DESCRIPTION
## Summary

Restructures the `src/content/` directory into logical subfolders (`buttons/`, `player/`, `events/`, `ui/`) and moves shared types to `src/shared/types.ts` for better maintainability and discoverability. No functional changes; purely organizational refactoring.

---

## Key Changes

### ✨ New Structure

| Before | After | Role |
|--------|-------|------|
| `content/buttons.ts` | `content/buttons/buttons.ts` | Button creation, SVG generation, labels |
| `content/helper.ts` | `content/buttons/helper.ts` | Button helpers, options parsing, SVG paths |
| `content/event-keys.ts` | `content/events/event-keys.ts` | Arrow/media key overrides, keyboard handling |
| `content/handle-video-player.ts` | `content/player/handle-video-player.ts` | Video seek updates (`updateVideoTime`) |
| `content/wait-for-player.ts` | `content/player/wait-for-player.ts` | RAF-based player-ready polling |
| `content/button-styles-sync.ts` | `content/ui/button-styles-sync.ts` | Native-style syncing for custom buttons |
| `content/tooltip.ts` | `content/ui/tooltip.ts` | Tooltip positioning and hover behavior |
| `content/types.ts` | `shared/types.ts` | Shared interfaces used by content and options |

### 🔧 Refactoring

- **Shared types** (`IOptions`, `IStorageOptions`, `ArrowKey`, `ButtonClassesIds`, etc.) moved from `src/content/types.ts` to `src/shared/types.ts` so both content scripts and options can import them without coupling to content.
- **Import paths** updated across all affected modules. Content modules now use relative paths like `../../shared/types`, `../events/event-keys`, `../player/handle-video-player`, etc.
- **Options page** imports `numberFormat` from `content/buttons/helper` and types from `shared/types`.
- **`IStorageOptions` formatting** in `shared/types.ts`: interface definition formatted for consistency (single-line `Omit` spread).
- **Lint cleanup**: Removed unnecessary `eslint-disable` comments in `options-page.ts` and `options-page.spec.ts` (`no-alert`, `no-restricted-globals`, `@typescript-eslint/no-unused-vars`).

### 📚 Documentation

- **`src/content/README.md`** (new): Describes content folder layout, entry point (`content.ts`), subfolder roles, shared types location, and related docs.
- **`AGENTS.md`**: Updated to reflect new paths (`shared/`, `content/buttons/`, `content/player/`, `content/events/`, `content/ui/`) and correct references to `handle-video-player.ts`, `helper.ts`, and types.
- **`content-trigger-flows.md`**: Added related-modules note pointing to `content/player/wait-for-player.ts`.

---

## Files Changed

### Content script modules (moved/renamed)
- `src/content/buttons.ts` → `src/content/buttons/buttons.ts`
- `src/content/helper.ts` → `src/content/buttons/helper.ts`
- `src/content/event-keys.ts` → `src/content/events/event-keys.ts`
- `src/content/handle-video-player.ts` → `src/content/player/handle-video-player.ts`
- `src/content/wait-for-player.ts` → `src/content/player/wait-for-player.ts`
- `src/content/button-styles-sync.ts` → `src/content/ui/button-styles-sync.ts`
- `src/content/tooltip.ts` → `src/content/ui/tooltip.ts`

### Shared
- `src/content/types.ts` → `src/shared/types.ts`

### Entry point & docs
- `src/content/content.ts` — import path updates
- `src/content/content-trigger-flows.md` — related-modules note
- `src/content/README.md` — **new**
- `AGENTS.md` — path and doc references

### Options
- `src/options/options-page.ts` — imports from `shared/types` and `content/buttons/helper`
- `src/options/__utils__/tests-helper.ts` — imports from `shared/types`
- `src/options/__tests__/options-page.spec.ts` — imports from `shared/types`, lint cleanup

### Unit tests (import path updates)
- `src/content/__tests__/buttons.spec.ts`
- `src/content/__tests__/content.spec.ts`
- `src/content/__tests__/event-keys.spec.ts`
- `src/content/__tests__/handle-video-player.spec.ts`
- `src/content/__tests__/helper.spec.ts`
- `src/content/__tests__/button-styles-sync.spec.ts`
- `src/content/__tests__/tooltip.spec.ts`
- `src/content/__tests__/wait-for-player.spec.ts`

### Test utilities
- `src/content/__utils__/tests-helper.ts` — imports from `shared/types` and `buttons/helper`

---

## Testing

### ✅ Unit tests

- All content-related Jest specs updated with new import paths.
- No test logic changes; only path updates.
- Run: `npm run jest:test` or `npm run jest:test:coverage`

### E2E

- No changes to `e2e-tests/` or DOM selectors; Playwright tests remain valid.

---

## Impact

### User-facing
- **None** — no behavior changes.

### Developer-facing
- Clearer module organization and easier discovery of where features live.
- Shared types live in `src/shared/` instead of `content/`.
- Content subfolders: `buttons/` (UI + helpers), `player/` (video logic), `events/` (keyboard), `ui/` (tooltips, styles).

---

## Migration Notes

- **No breaking changes** — public APIs (message formats, settings keys in `types.d.ts`) unchanged.
- **No manifest changes** — `content/content.ts` remains the content script entry; Parcel bundling handles the new structure.
- Anyone with local branches that touch `content/*` or `content/types.ts` should rebase and update imports to match the new layout.
